### PR TITLE
reverting change on tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,9 @@
     "strictNullChecks": false,
     "strict": false,
   },
+  "include": [
+    "src/"
+  ],
   "exclude": [
     "**/*.spec.ts"
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "moduleResolution": "node",
     "target": "ES2018", // ~node10
     "module": "commonjs",
     "lib": [
@@ -18,9 +17,6 @@
     "strictNullChecks": false,
     "strict": false,
   },
-  "include": [
-    "src/"
-  ],
   "exclude": [
     "**/*.spec.ts"
   ]


### PR DESCRIPTION
adding `"moduleResolution": "node",` to config.js did not solve the github build errors, to reverting the changes.

This article seem to give some clues about issue:
https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping