### PR TITLE
remove dev and test files from published npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -130,3 +130,7 @@ dist
 .yarn/unplugged
 .yarn/build-state.yml
 .pnp.*
+
+.github/
+.homebridge-dev/
+test/


### PR DESCRIPTION

There are a few dev / test folders that were getting into the published package, and they don't need to be there.
