### PR TITLE
feat: add support for rgbcw bulbs

### DIFF
--- a/src/accessories/RGBCWBulb.ts
+++ b/src/accessories/RGBCWBulb.ts
@@ -1,0 +1,102 @@
+import {
+  clamp,
+  convertHSLtoRGB,
+  convertMiredToTempInKelvin,
+  convertRGBtoHSL,
+  convertTempInKelvinToWhiteValues,
+} from '../magichome-interface/utils';
+import { HomebridgeMagichomeDynamicPlatformAccessory } from '../platformAccessory';
+
+export class RGBCWBulb extends HomebridgeMagichomeDynamicPlatformAccessory {
+  async updateDeviceState(_timeout = 200) {
+    //**** local variables ****\\
+    const hsl = this.lightState.HSL;
+    const isColorTempChange = this.setColortemp;
+    let [red, green, blue] = [0, 0, 0];
+    if (!isColorTempChange) {
+      [red, green, blue] = convertHSLtoRGB(hsl); //convert HSL to RGB
+    }
+    const brightness = this.lightState.brightness;
+    const mask = isColorTempChange ? 0x0f : 0xf0; // the 'mask' byte tells the controller which LEDs to turn on color(0xF0), white (0x0F), or both (0xFF)
+    //we default the mask to turn on color. Other values can still be set, they just wont turn on
+
+    //sanitize our color/white values with Math.round and clamp between 0 and 255, not sure if either is needed
+    //next determine brightness by dividing by 100 and multiplying it back in as brightness (0-100)
+    const r = Math.round((clamp(red, 0, 255) / 100) * brightness);
+    const g = Math.round((clamp(green, 0, 255) / 100) * brightness);
+    const b = Math.round((clamp(blue, 0, 255) / 100) * brightness);
+
+    const temperatureInKelvin = convertMiredToTempInKelvin(this.lightState.CCT);
+    const brightnessPercentage = brightness / 100;
+
+    const whiteValues = convertTempInKelvinToWhiteValues(
+      temperatureInKelvin,
+      brightnessPercentage,
+    );
+
+    await this.send(
+      [0x31, r, g, b, whiteValues.warmWhite, whiteValues.coldWhite, mask, mask],
+      true,
+      _timeout,
+    ); //9th byte checksum calculated later in send()
+  }
+
+  async updateHomekitState() {
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.On,
+      this.lightState.isOn,
+    );
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.Hue,
+      this.lightState.HSL.hue,
+    );
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.Saturation,
+      this.lightState.HSL.saturation,
+    );
+    if (this.lightState.HSL.luminance > 0 && this.lightState.isOn) {
+      this.service.updateCharacteristic(
+        this.platform.Characteristic.Brightness,
+        this.lightState.HSL.luminance * 2,
+      );
+    } else if (this.lightState.isOn) {
+      this.service.updateCharacteristic(
+        this.platform.Characteristic.Brightness,
+        clamp(
+          this.lightState.whiteValues.coldWhite / 2.55 +
+            this.lightState.whiteValues.warmWhite / 2.55,
+          0,
+          100,
+        ),
+      );
+      if (
+        this.lightState.whiteValues.warmWhite >
+        this.lightState.whiteValues.coldWhite
+      ) {
+        this.service.updateCharacteristic(
+          this.platform.Characteristic.Saturation,
+          this.colorWhiteThreshold -
+            this.colorWhiteThreshold *
+              (this.lightState.whiteValues.coldWhite / 255),
+        );
+        this.service.updateCharacteristic(this.platform.Characteristic.Hue, 0);
+      } else {
+        this.service.updateCharacteristic(
+          this.platform.Characteristic.Saturation,
+          this.colorWhiteThreshold -
+            this.colorWhiteThreshold *
+              (this.lightState.whiteValues.warmWhite / 255),
+        );
+        this.service.updateCharacteristic(
+          this.platform.Characteristic.Hue,
+          180,
+        );
+      }
+    }
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.ColorTemperature,
+      this.lightState.CCT,
+    );
+    this.cacheCurrentLightState();
+  }
+}

--- a/src/magichome-interface/LightMap.ts
+++ b/src/magichome-interface/LightMap.ts
@@ -46,6 +46,17 @@ const lightTypesMap: Map<number, ILightParameters> = new Map([
     },
   ],
   [
+    0x0e,
+    {
+      controllerLogicType: ControllerTypes.RGBCWBulb,
+      convenientName: 'RGBCW Bulb',
+      simultaneousCCT: false,
+      hasColor: true,
+      hasCCT: true,
+      hasBrightness: true,
+    },
+  ],
+  [
     0x21,
     {
       controllerLogicType: ControllerTypes.DimmerStrip,

--- a/src/magichome-interface/types.ts
+++ b/src/magichome-interface/types.ts
@@ -28,6 +28,7 @@ export enum ControllerTypes {
     DimmerStrip = 'DimmerStrip',
     GRBStrip = 'GRBStrip',
     RGBWWBulb = 'RGBWWBulb',
+    RGBCWBulb = 'RGBCWBulb',
     RGBWBulb = 'RGBWBulb',
     Switch = 'Switch',
     RGBStrip = 'RGBStrip'

--- a/src/magichome-interface/utils.ts
+++ b/src/magichome-interface/utils.ts
@@ -137,6 +137,63 @@ export function convertHSLtoRGB ({hue, saturation, luminance}) {
 //=================================================
 // End Convert HSLtoRGB //
 
+const MIN_TEMPERATURE_IN_KELVIN = 2000;
+const MAX_TEMPERATURE_IN_KELVIN = 7200;
+
+/**
+ * Converts white values to temperature in degrees Kelvin and associated brightness percentage.
+ * @param whiteValues byte values for warm white and cold white
+ * @returns temperature in degrees Kelvin and brightness percentage
+ */
+export function convertWhiteValuesToTempInKelvinAndBrightness(
+  whiteValues: { warmWhite: number; coldWhite: number },
+  minTemp = MIN_TEMPERATURE_IN_KELVIN,
+  maxTemp = MAX_TEMPERATURE_IN_KELVIN,
+): { temperature: number; brightnessPercentage: number } {
+  let temperature = minTemp;
+  const warm = whiteValues.warmWhite / 255;
+  const cold = whiteValues.coldWhite / 255;
+  const brightness = cold + warm;
+  if (brightness !== 0) {
+    temperature = (cold / brightness) * (maxTemp - minTemp) + minTemp;
+  }
+  return { temperature: temperature, brightnessPercentage: brightness * 100 };
+}
+
+/**
+ * Converts temperature in degrees Kelvin and associated brightness percentage to byte values for warm white and cold white
+ * @param kelvin temperature in degrees Kelvin
+ * @param brightnessPercentage brightness as a percentage value
+ * @returns byte values for warm white and cold white
+ */
+export function convertTempInKelvinToWhiteValues(
+  kelvin: number,
+  brightnessPercentage: number,
+  minTemp = MIN_TEMPERATURE_IN_KELVIN,
+  maxTemp = MAX_TEMPERATURE_IN_KELVIN,
+): { warmWhite: number; coldWhite: number } {
+  const warm =
+    ((maxTemp - kelvin) / (maxTemp - minTemp)) * brightnessPercentage;
+  const cold = brightnessPercentage - warm;
+  const ww = Math.round(255 * warm);
+  const cw = Math.round(255 * cold);
+  return { warmWhite: ww, coldWhite: cw };
+}
+
+/**
+ * Converts from temperature in Kelvin (ex. 6500) to mired (micro-reciprocal degrees), as used by HomeKit
+ */
+export function convertTempInKelvinToMired(kelvin: number): number {
+  return 1000000 / kelvin;
+}
+
+/**
+ * Converts from mired (micro-reciprocal degrees), as used by HomeKit, to temperature in Kelvin (ex. 6500)
+ */
+export function convertMiredToTempInKelvin(mired: number) {
+  return 1000000 / mired;
+}
+
 export function parseJson<T>(value: string, replacement: T): T {
   try {
     return <T>JSON.parse(value);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -9,6 +9,7 @@ import { RGBStrip } from './accessories/RGBStrip';
 import { GRBStrip } from './accessories/GRBStrip';
 import { RGBWBulb } from './accessories/RGBWBulb';
 import { RGBWWBulb } from './accessories/RGBWWBulb';
+import { RGBCWBulb } from './accessories/RGBCWBulb';
 import { RGBWStrip } from './accessories/RGBWStrip';
 import { RGBWWStrip } from './accessories/RGBWWStrip';
 import { CCTStrip } from './accessories/CCTStrip';
@@ -30,6 +31,7 @@ const accessoryType = {
   RGBStrip,
   RGBWBulb,
   RGBWWBulb,
+  RGBCWBulb,
   RGBWStrip,
   RGBWWStrip,
   CCTStrip,


### PR DESCRIPTION
bulbs with hardware version 0x0e are RGBCW bulbs which are currently unsupported. add support for these types of bulbs and enable setting the color temperature directly, transforming between mired (micro-reciprocal degrees) as used by HomeKit and white values, rather than transforming HSL values.