### PR TITLE
feat: Homebridge 2 readiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     }
   ],
   "engines": {
-    "node": ">=10.17.0",
-    "homebridge": ">0.4.53"
+    "node": "^22.12.0 || ^24.0.0",
+    "homebridge": "^1.6.0 || ^2.0.0"
   },
   "main": "dist/index.js",
   "scripts": {
@@ -63,15 +63,15 @@
     "promise-queue": "^2.2.5"
   },
   "devDependencies": {
-    "@types/node": "^14.0.23",
+    "@types/node": "^22.19.19",
     "@types/promise-queue": "^2.2.0",
     "@typescript-eslint/eslint-plugin": "^3.8.0",
     "@typescript-eslint/parser": "^3.8.0",
     "eslint": "^7.6.0",
-    "homebridge": "^1.1.1",
+    "homebridge": "^2.0.2",
     "nodemon": "^2.0.4",
     "rimraf": "^3.0.2",
     "ts-node": "^8.10.2",
-    "typescript": "^3.9.7"
+    "typescript": "^5.9.3"
   }
 }

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -540,9 +540,10 @@ export class HomebridgeMagichomeDynamicPlatformAccessory {
         if (( !this.colorCommand) || !this.lightState.isOn){ //if no color command or a command to turn the light off
           await this.send(this.lightState.isOn ? COMMAND_POWER_ON : COMMAND_POWER_OFF); // set the power
         } else {
-          if((this.myDevice.controllerFirmwareVersion <= 5 && this.myDevice.controllerFirmwareVersion > 1) 
-          || this.myDevice.controllerFirmwareVersion == 8 
-          || (this.myDevice.controllerFirmwareVersion == 1 && this.myDevice.modelNumber.includes('HF-LPB100-ZJ200'))){ 
+          const fwVersion = Number(this.myDevice.controllerFirmwareVersion);
+          if((fwVersion <= 5 && fwVersion > 1)
+          || fwVersion == 8
+          || (fwVersion == 1 && this.myDevice.modelNumber.includes('HF-LPB100-ZJ200'))){
             await this.send( COMMAND_POWER_ON ); // set the power
           }
           setTimeout(   async () =>  {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "esModuleInterop": true,
     "strictNullChecks": false,
     "strict": false,
+    "skipLibCheck": true,
   },
   "include": [
     "src/"


### PR DESCRIPTION
Adds compatibility with Homebridge v2 while keeping v1 support. Minimal, focused changes: dependency bumps, one tsconfig flag, and one type-narrowing fix.

closes #155 
