### PR TITLE
fix: Confirm Readiness for Homebridge 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "engines": {
     "node": ">=10.17.0",
-    "homebridge": ">0.4.53"
+    "homebridge": "^1.8.0 || ^2.0.0"
   },
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Closes #155

Patch generated by `qwen3.6-35b-a3b via local API`.